### PR TITLE
An update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.0.2 - 2026-08-04
+- [GRD-1175](https://jira.oicr.on.ca/browse/GRD-1175) 
+- Updated to support hg38_noAlt reference 
+- Fixed an error in contig splitting 
+
 ## 5.0.1 - 2023-12-01
 - [GRD-683](https://jira.oicr.on.ca/browse/GRD-683) 
 - Added "readGroup" argument

--- a/ConsensusCruncher/DCS_maker.py
+++ b/ConsensusCruncher/DCS_maker.py
@@ -213,7 +213,7 @@ def main():
             read_start = None
             read_end = None
         else:
-            read_chr = x.split('_', 1)[0]
+            read_chr = x.rsplit('_', 1)[0]
             read_start = division_coor[x][0]
             read_end = division_coor[x][1]
 

--- a/ConsensusCruncher/SSCS_maker.py
+++ b/ConsensusCruncher/SSCS_maker.py
@@ -275,7 +275,7 @@ def main():
             read_start = None
             read_end = None
         else:
-            read_chr = x.split('_', 1)[0]
+            read_chr = x.rsplit('_', 1)[0]
             read_start = division_coor[x][0]
             read_end = division_coor[x][1]
 

--- a/ConsensusCruncher/singleton_correction.py
+++ b/ConsensusCruncher/singleton_correction.py
@@ -212,7 +212,7 @@ def main():
             read_start = None
             read_end = None
         else:
-            read_chr = x.split('_', 1)[0]
+            read_chr = x.rsplit('_', 1)[0]
             read_start = division_coor[x][0]
             read_end = division_coor[x][1]
 


### PR DESCRIPTION
Contigs were being split by the first encountered _ and this works fine for chr1_p11.1 and returns chr1 for a bed file lookup but for chrUn_KI270302v1_p11.1 it throws an error since the bed file contains chrUn_KI270302v1 and chrUn was being returned after the split instead of chrUn_KI270302v1. To fix this I have incorporated rsplit and now:
chr1_p11.1 still returns chr1 and chrUn_KI270302v1_p11.1 returns chrUn_KI270302v1. 

